### PR TITLE
chore: align tool IDs and bump core deps

### DIFF
--- a/backend/aggregator_test.go
+++ b/backend/aggregator_test.go
@@ -99,11 +99,11 @@ func TestAggregator_ParseToolID(t *testing.T) {
 	}{
 		{"local:echo", "local", "echo", false},
 		{"github:create_issue", "github", "create_issue", false},
-		{"github:create_issue:1.0.0", "", "", true},
+		{"github:create_issue:1.0.0", "github", "create_issue:1.0.0", false},
 		{"my-backend:my_tool", "my-backend", "my_tool", false},
 		{"no_namespace", "", "no_namespace", false},
 		{"", "", "", true},
-		{"bad:format:tool", "", "", true},
+		{"bad:format:tool", "bad", "format:tool", false},
 		{"too:many:colons:here", "", "", true},
 	}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,9 @@ The `runtime` package provides isolation levels via security profiles:
 - **Standard**: container or sandbox runtime
 - **Hardened**: strongest isolation (Docker/gVisor/WASM)
 
+Concrete runtime SDK clients (Kubernetes, Proxmox, remote HTTP) live in
+`toolexec-integrations` and are injected into the core backends via interfaces.
+
 ## Observability
 
 Execution surfaces timing and tool call metadata in `exec.Result` and

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ backend.RegisterHandler("add", local.ToolDef{
 - **Tool Chaining**: Chain multiple tool calls with `UsePrevious` result passing
 - **Security Profiles**: Dev, Standard, and Hardened isolation levels
 - **Runtime Isolation**: Sandbox untrusted code with Docker, containerd, Kubernetes, gVisor, Kata, Firecracker, WASM, remote, or Proxmox LXC backends
+- **Integration Boundary**: Concrete runtime SDK clients live in `toolexec-integrations` and are injected into core backends via interfaces
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/jonwraymond/toolexec
 go 1.25.6
 
 require (
-	github.com/jonwraymond/tooldiscovery v0.2.1
-	github.com/jonwraymond/toolfoundation v0.2.0
+	github.com/jonwraymond/tooldiscovery v0.3.0
+	github.com/jonwraymond/toolfoundation v0.3.0
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	golang.org/x/text v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -52,10 +52,10 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/jonwraymond/tooldiscovery v0.2.1 h1:/XBhHSrnSCPs+Cea9EivnIjJccJMcJa5BoC0qwJ8flg=
-github.com/jonwraymond/tooldiscovery v0.2.1/go.mod h1:2LxR6cm4RUPu+o88QstDdfLVAABmYan2TWE6eg1xtcU=
-github.com/jonwraymond/toolfoundation v0.2.0 h1:Uqk0XPVCPFi4vtOn8R9Y/965KhxU3ptaZSCaN5N3qXg=
-github.com/jonwraymond/toolfoundation v0.2.0/go.mod h1:sUvAa1lxc/l57jdC+hAQVWKky3wpobDB2sNo40lQSCY=
+github.com/jonwraymond/tooldiscovery v0.3.0 h1:RbyDF5SMQIT+emiqiFgPvp17z5d/rbjxMPFFxxg+amA=
+github.com/jonwraymond/tooldiscovery v0.3.0/go.mod h1:GWUQ6gC9197ATs4iAdQufJnWIuPnFxtcLF5WpOKZqVI=
+github.com/jonwraymond/toolfoundation v0.3.0 h1:lRmmGeImojZk1iTpgjQDHGieel/IiTbsLlQe13UrRng=
+github.com/jonwraymond/toolfoundation v0.3.0/go.mod h1:sUvAa1lxc/l57jdC+hAQVWKky3wpobDB2sNo40lQSCY=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=


### PR DESCRIPTION
## Summary\n- Align tool ID parsing expectations for versioned identifiers\n- Bump tooldiscovery/toolfoundation to v0.3.0\n- Document toolexec-integrations boundary\n\n## Testing\n- GOWORK=off go test ./...